### PR TITLE
AreaQuantity improvement

### DIFF
--- a/Source/DTDLv2/RealEstateCore/Information/AreaQuantity/AreaQuantity.json
+++ b/Source/DTDLv2/RealEstateCore/Information/AreaQuantity/AreaQuantity.json
@@ -1,0 +1,43 @@
+{
+  "@id": "dtmi:org:w3id:rec:AreaQuantity;1",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "value"
+      },
+      "name": "value",
+      "schema": "float",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "type"
+      },
+      "name": "type",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "measurement unit"
+      },
+      "name": "measurementUnit",
+      "schema": "string",
+      "writable": true
+    }
+  ],
+  "description": {
+    "en": "Describes business-relevant area measurements typically associated with architected spaces."
+  },
+  "displayName": {
+    "en": "AreaQuantity"
+  },
+  "extends": "dtmi:org:w3id:rec:Information;1",
+  "@context": [
+    "dtmi:dtdl:context;2"
+  ]
+}

--- a/Source/DTDLv2/RealEstateCore/Information/AreaQuantity/SquareMeter_.json
+++ b/Source/DTDLv2/RealEstateCore/Information/AreaQuantity/SquareMeter_.json
@@ -1,0 +1,14 @@
+{
+  "@id": "dtmi:org:w3id:rec:SquareMeterAreaQuantity;1",
+  "@type": "Interface",
+  "description": {
+    "en": "SquareMeter Area Quantity."
+  },
+  "displayName": {
+    "en": "SquareMeterAreaQuantity"
+  },
+  "extends": "dtmi:org:w3id:rec:AreaQuantity;1",
+  "@context": [
+    "dtmi:dtdl:context;2"
+  ]
+}


### PR DESCRIPTION
REC4 has [ArchitectureArea](https://dev.realestatecore.io/ontology/Information/ArchitectureArea), with an encouragement to subclass.
Our extension of REC3.3 has AreaQuantity, described below, which has some native alternative areas but allows for general use without private subclassing.
We suggest merging something like AreaQuantity into ArchitectureArea.

AreaQuantity is a new subclass of [Information](https://dev.realestatecore.io/ontology/Information/Information) to describe the area as a scalar, to describe a space (square meters total, rentable, heated, or other industry metrics).
AreaQuantity contains three fields:
- value
- type
- measurmentUnit

**Display name:** AreaQuantity
**DTMI:** dtmi:org:w3id:rec:AreaQuantity;1

SquareMeterAreaQuantity is a subclass of AreaQuantity, where "measurmentUnit" field is always "square meters".

**Display name:** SquareMeterAreaQuantity
**DTMI:** dtmi:org:w3id:rec:SquareMeterAreaQuantity;1

Example of AreaQuantity:
```
{
   "type": "BOA/LOA/ATEMP/free text",
   "value" : number
   "measurementUnit": SquareMeter
}
```


